### PR TITLE
Fix GitHub Action problems

### DIFF
--- a/.github/workflows/clean_tests.yml
+++ b/.github/workflows/clean_tests.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Setup BATS testing framework
-      uses: mig4/setup-bats@v1.0.1
+      uses: mig4/setup-bats@v1.2.0
     - name: Check out the code
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/compile_tests.yml
+++ b/.github/workflows/compile_tests.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Setup BATS testing framework
-      uses: mig4/setup-bats@v1.0.1
+      uses: mig4/setup-bats@v1.2.0
     - name: Check out the code
       uses: actions/checkout@v2
       with:


### PR DESCRIPTION
I think this pull request will fix the GitHub Actions problems. If it does, then this should fix your badge for the `compiling` tests and give you a green check by the `compiling` actions.

You won't pass all the checks yet because you haven't finished the `cleaning` part of the lab, but this should allow those to also pass when you finish them.

The badges won't update immediately, and sometimes browser caching delays being able to see that they're better as well, but hopefully this will turn the `compiling` badge green.